### PR TITLE
fix(bst): refactor find, add min/max, encapsulate keys/values

### DIFF
--- a/lib/src/main/kotlin/team8/bstlib/BinarySearchTree.kt
+++ b/lib/src/main/kotlin/team8/bstlib/BinarySearchTree.kt
@@ -1,12 +1,26 @@
 package team8.bstlib
 
 sealed class BinarySearchTree<K : Comparable<K>, V, N : BinarySearchTreeNode<K, V, N>>(rootKey: K, rootValue: V) {
-    protected abstract val root: N
+    protected abstract var root: N?
 
     val keys: MutableList<K> = mutableListOf(rootKey)
+        private set
+
     val values: MutableList<V> = mutableListOf(rootValue)
+        private set
 
     abstract fun insert(key: K, value: V): N?
-    abstract fun remove(key: K, value: V): N?
-    abstract fun find(key: K, value: V): N?
+    abstract fun remove(key: K): N?
+
+    fun find(key: K): N? {
+        fun recursiveFind(currentNode: N?): N? {
+            if (currentNode == null || currentNode.key == key) return currentNode
+            return if (key > currentNode.key) {
+                recursiveFind(currentNode.rightChild)
+            } else {
+                recursiveFind(currentNode.leftChild)
+            }
+        }
+        return recursiveFind(root)
+    }
 }

--- a/lib/src/main/kotlin/team8/bstlib/BinarySearchTreeNode.kt
+++ b/lib/src/main/kotlin/team8/bstlib/BinarySearchTreeNode.kt
@@ -4,4 +4,20 @@ sealed class BinarySearchTreeNode<K : Comparable<K>, V, N : BinarySearchTreeNode
     var leftChild: N? = null
     var rightChild: N? = null
     var parent: N? = null
+
+    fun findMin(): N {
+        return if (leftChild == null) {
+            this as N
+        } else {
+            leftChild!!.findMin()
+        }
+    }
+
+    fun findMax(): N {
+        return if (rightChild == null) {
+            this as N
+        } else {
+            rightChild!!.findMax()
+        }
+    }
 }


### PR DESCRIPTION
Fix `find` traversal logic (check right subtree for `key > current.key`)  
Make `root` mutable (`var`) for dynamic updates  
Add `private set` to `keys` and `values` to prevent external modification  
Implement `findMin()` and `findMax()` in BSTNode  
Sync `keys` and `values` on insert/remove  