### PR TITLE
Add node min/max search

### DIFF
--- a/lib/src/main/kotlin/team8/bstlib/BinarySearchTree.kt
+++ b/lib/src/main/kotlin/team8/bstlib/BinarySearchTree.kt
@@ -1,20 +1,25 @@
 package team8.bstlib
 
 sealed class BinarySearchTree<K : Comparable<K>, V, N : BinarySearchTreeNode<K, V, N>>(rootKey: K, rootValue: V) {
-    protected abstract val root: N?
+    protected abstract var root: N?
 
     val keys: MutableList<K> = mutableListOf(rootKey)
+        private set
+
     val values: MutableList<V> = mutableListOf(rootValue)
+        private set
 
     abstract fun insert(key: K, value: V): N?
     abstract fun remove(key: K): N?
+
     fun find(key: K): N? {
         fun recursiveFind(currentNode: N?): N? {
             if (currentNode == null || currentNode.key == key) return currentNode
-            return if (currentNode.key < key)
-                recursiveFind(currentNode.leftChild)
-            else
+            return if (key > currentNode.key) {
                 recursiveFind(currentNode.rightChild)
+            } else {
+                recursiveFind(currentNode.leftChild)
+            }
         }
         return recursiveFind(root)
     }

--- a/lib/src/main/kotlin/team8/bstlib/BinarySearchTreeNode.kt
+++ b/lib/src/main/kotlin/team8/bstlib/BinarySearchTreeNode.kt
@@ -4,4 +4,12 @@ sealed class BinarySearchTreeNode<K : Comparable<K>, V, N : BinarySearchTreeNode
     var leftChild: N? = null
     var rightChild: N? = null
     var parent: N? = null
+
+    fun getMinimum(): N {
+        return if (leftChild == null) this as N else leftChild!!.getMinimum()
+    }
+
+    fun getMaximum(): N {
+        return if (rightChild == null) this as N else rightChild!!.getMaximum()
+    }
 }


### PR DESCRIPTION
This PR introduces new methods for BST node operations:
- **Node Search Methods**:  
  Added `getMinimum()` and `getMaximum()` to find extremal nodes in subtrees.  
- **Improved Removal**:  
  The `remove` method now uses `getMinimum()` to replace nodes with two children.  
