### PR TITLE
Fix mutable root and corrected find traversal

### DIFF
--- a/lib/src/main/kotlin/team8/bstlib/BinarySearchTree.kt
+++ b/lib/src/main/kotlin/team8/bstlib/BinarySearchTree.kt
@@ -1,10 +1,13 @@
 package team8.bstlib
 
 sealed class BinarySearchTree<K : Comparable<K>, V, N : BinarySearchTreeNode<K, V, N>>(rootKey: K, rootValue: V) {
-    protected abstract val root: N?
+    protected abstract var root: N?
 
     val keys: MutableList<K> = mutableListOf(rootKey)
+        private set
+
     val values: MutableList<V> = mutableListOf(rootValue)
+        private set
 
     abstract fun insert(key: K, value: V): N?
     abstract fun remove(key: K): N?
@@ -12,10 +15,9 @@ sealed class BinarySearchTree<K : Comparable<K>, V, N : BinarySearchTreeNode<K, 
         fun recursiveFind(currentNode: N?): N? {
             if (currentNode == null || currentNode.key == key) return currentNode
             return if (currentNode.key < key)
-                recursiveFind(currentNode.leftChild)
-            else
                 recursiveFind(currentNode.rightChild)
-        }
+            else
+                recursiveFind(currentNode.leftChild)        }
         return recursiveFind(root)
     }
 }


### PR DESCRIPTION
This PR fixes core issues in the BST implementation:
- **Mutable Root**:  
  The `root` is now `var`, allowing dynamic updates during tree operations.  
- **Corrected Find Traversal**:  
  The `find` method now correctly traverses the right subtree.
- **Data Encapsulation**:  
  Added `private set` to `keys` and `values` to protect them from unintended external changes.  